### PR TITLE
Use env.example consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ services:
     #     max-file: "3"
 ```
 
-See `.env.example` for variables.
+See `env.example` for variables.
 
 ---
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@
 # Builds the local Dockerfile and runs the probe in a loop.
 #
 # Usage:
-#   1) Copy .env.example to .env and fill in values.
+#   1) Copy env.example to .env and fill in values.
 #   2) docker compose up --build
 #
 # Notes:

--- a/env.example
+++ b/env.example
@@ -1,4 +1,4 @@
-# .env.example
+# env.example
 # Copy to .env and fill in values. Do not commit your real secrets.
 
 # Core


### PR DESCRIPTION
## Summary
- standardize docs on `env.example`
- update example env file header

## Testing
- `bash -n entrypoint.sh`
- `docker compose config` *(fails: command not found)*
- YAML parse attempt *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a5dff784b4832aba2fb2ece2922e95