### PR TITLE
Add smoke test for container build

### DIFF
--- a/tests/container_test.sh
+++ b/tests/container_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Simple smoke tests for vpn-probe container
+set -euo pipefail
+
+IMAGE_TAG="vpn-probe:test"
+
+echo "Building image..."
+docker build -t "$IMAGE_TAG" .
+
+echo "Ensuring missing env var causes failure..."
+OUTPUT=$(docker run --rm "$IMAGE_TAG" 2>&1 || true)
+echo "$OUTPUT" | grep -q "Missing VPN_URL"
+
+echo "Ensuring openconnect is available..."
+docker run --rm --entrypoint openconnect "$IMAGE_TAG" --version >/dev/null
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- add smoke test script to build container and verify openconnect availability

## Testing
- `bash tests/container_test.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e1fd9d74832a9759dfea60ab958e